### PR TITLE
fix movie generation on newer matplotlib

### DIFF
--- a/pySW4/plotting/image.py
+++ b/pySW4/plotting/image.py
@@ -12,7 +12,7 @@ import os
 import re
 import subprocess
 import warnings
-from io import StringIO
+from io import BytesIO
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -94,7 +94,7 @@ def image_files_to_movie(
         '-vcodec', 'libx264', '-pass', '1', '-vb', '6M', '-pix_fmt', 'yuv420p',
         output_filename)
 
-    string_io = StringIO()
+    bytes_io = BytesIO()
     backend = plt.get_backend()
     try:
         plt.switch_backend('AGG')
@@ -106,11 +106,11 @@ def image_files_to_movie(
             patch = image.patches[patch_number]
             fig, _, _ = patch.plot(**plot_kwargs)
             fig.tight_layout()
-            fig.savefig(string_io, format='png')
+            fig.savefig(bytes_io, format='png')
             plt.close(fig)
-        string_io.seek(0)
-        png_data = string_io.read()
-        string_io.close()
+        bytes_io.seek(0)
+        png_data = bytes_io.read()
+        bytes_io.close()
         sub = subprocess.Popen(cmdstring, stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = sub.communicate(png_data)


### PR DESCRIPTION
It seems that on newer matplotlib our code fails because `Figure.savefig()` doesn't accept a `StringIO` instance anymore.. need to double check..

```
/home/megies/anaconda/envs/pySW4/lib/python2.7/site-packages/pySW4/plotting/image.py:212: UserWarning: Failed to create a movie: unicode argument expected, got 'str'
  warnings.warn(msg)
```

```python
(Pdb) n
> /home/megies/anaconda/envs/pySW4/lib/python2.7/site-packages/pySW4/plotting/image.py(109)image_files_to_movie()
-> fig.savefig(string_io, format='png')
(Pdb) n
TypeError: "unicode argument expected, got 'str'"
```